### PR TITLE
Add manual register-level GPIO toggle example

### DIFF
--- a/ManualGPIO_Toggle/Drivers/Inc/gpio_driver.h
+++ b/ManualGPIO_Toggle/Drivers/Inc/gpio_driver.h
@@ -1,0 +1,28 @@
+#ifndef GPIO_DRIVER_H
+#define GPIO_DRIVER_H
+
+#include "stm32f4xx_custom.h"
+
+typedef struct {
+    uint8_t GPIO_PinNumber;
+    uint8_t GPIO_PinMode;
+    uint8_t GPIO_PinPuPdControl;
+} GPIO_PinConfig_t;
+
+typedef struct {
+    GPIO_RegDef_t *pGPIOx;
+    GPIO_PinConfig_t GPIO_PinConfig;
+} GPIO_Handle_t;
+
+#define GPIO_MODE_IN   0
+#define GPIO_MODE_OUT  1
+#define GPIO_NO_PUPD   0
+#define GPIO_PIN_NO_0  0
+#define GPIO_PIN_NO_12 12
+
+void GPIO_PeriClockControl(GPIO_RegDef_t *pGPIOx, uint8_t EnOrDi);
+void GPIO_Init(GPIO_Handle_t *pGPIOHandle);
+uint8_t GPIO_ReadFromInputPin(GPIO_RegDef_t *pGPIOx, uint8_t PinNumber);
+void GPIO_ToggleOutputPin(GPIO_RegDef_t *pGPIOx, uint8_t PinNumber);
+
+#endif /* GPIO_DRIVER_H */

--- a/ManualGPIO_Toggle/Drivers/Inc/stm32f4xx_custom.h
+++ b/ManualGPIO_Toggle/Drivers/Inc/stm32f4xx_custom.h
@@ -1,0 +1,56 @@
+#ifndef STM32F4XX_CUSTOM_H
+#define STM32F4XX_CUSTOM_H
+
+#include <stdint.h>
+
+/* Peripheral Base Addresses */
+#define PERIPH_BASE        0x40000000UL
+#define AHB1PERIPH_BASE    (PERIPH_BASE + 0x00020000UL)
+
+/* GPIO Base Addresses */
+#define GPIOA_BASE         (AHB1PERIPH_BASE + 0x0000UL)
+#define GPIOD_BASE         (AHB1PERIPH_BASE + 0x0C00UL)
+
+/* RCC Base Address */
+#define RCC_BASE           (AHB1PERIPH_BASE + 0x3800UL)
+
+/* GPIO Register Definition */
+typedef struct {
+  volatile uint32_t MODER;
+  volatile uint32_t OTYPER;
+  volatile uint32_t OSPEEDR;
+  volatile uint32_t PUPDR;
+  volatile uint32_t IDR;
+  volatile uint32_t ODR;
+  volatile uint32_t BSRR;
+  volatile uint32_t LCKR;
+  volatile uint32_t AFR[2];
+} GPIO_RegDef_t;
+
+/* RCC Register Definition */
+typedef struct {
+  volatile uint32_t CR;
+  volatile uint32_t PLLCFGR;
+  volatile uint32_t CFGR;
+  volatile uint32_t CIR;
+  volatile uint32_t AHB1RSTR;
+  volatile uint32_t AHB2RSTR;
+  volatile uint32_t AHB3RSTR;
+  uint32_t RESERVED0;
+  volatile uint32_t APB1RSTR;
+  volatile uint32_t APB2RSTR;
+  uint32_t RESERVED1[2];
+  volatile uint32_t AHB1ENR;
+  volatile uint32_t AHB2ENR;
+  volatile uint32_t AHB3ENR;
+  uint32_t RESERVED2;
+  volatile uint32_t APB1ENR;
+  volatile uint32_t APB2ENR;
+} RCC_RegDef_t;
+
+/* Peripheral Instances */
+#define GPIOA ((GPIO_RegDef_t *)GPIOA_BASE)
+#define GPIOD ((GPIO_RegDef_t *)GPIOD_BASE)
+#define RCC   ((RCC_RegDef_t *)RCC_BASE)
+
+#endif /* STM32F4XX_CUSTOM_H */

--- a/ManualGPIO_Toggle/Drivers/Src/gpio_driver.c
+++ b/ManualGPIO_Toggle/Drivers/Src/gpio_driver.c
@@ -1,0 +1,33 @@
+#include "gpio_driver.h"
+
+void GPIO_PeriClockControl(GPIO_RegDef_t *pGPIOx, uint8_t EnOrDi) {
+    if (EnOrDi) {
+        if (pGPIOx == GPIOA) RCC->AHB1ENR |= (1 << 0);
+        else if (pGPIOx == GPIOD) RCC->AHB1ENR |= (1 << 3);
+    }
+}
+
+void GPIO_Init(GPIO_Handle_t *pGPIOHandle) {
+    uint32_t temp = 0;
+
+    /* Enable clock */
+    GPIO_PeriClockControl(pGPIOHandle->pGPIOx, 1);
+
+    /* Configure MODER */
+    temp = (pGPIOHandle->GPIO_PinConfig.GPIO_PinMode << (2 * pGPIOHandle->GPIO_PinConfig.GPIO_PinNumber));
+    pGPIOHandle->pGPIOx->MODER &= ~(0x3 << (2 * pGPIOHandle->GPIO_PinConfig.GPIO_PinNumber));
+    pGPIOHandle->pGPIOx->MODER |= temp;
+
+    /* Configure PUPDR */
+    temp = (pGPIOHandle->GPIO_PinConfig.GPIO_PinPuPdControl << (2 * pGPIOHandle->GPIO_PinConfig.GPIO_PinNumber));
+    pGPIOHandle->pGPIOx->PUPDR &= ~(0x3 << (2 * pGPIOHandle->GPIO_PinConfig.GPIO_PinNumber));
+    pGPIOHandle->pGPIOx->PUPDR |= temp;
+}
+
+uint8_t GPIO_ReadFromInputPin(GPIO_RegDef_t *pGPIOx, uint8_t PinNumber) {
+    return (uint8_t)((pGPIOx->IDR >> PinNumber) & 0x1);
+}
+
+void GPIO_ToggleOutputPin(GPIO_RegDef_t *pGPIOx, uint8_t PinNumber) {
+    pGPIOx->ODR ^= (1 << PinNumber);
+}

--- a/ManualGPIO_Toggle/main.c
+++ b/ManualGPIO_Toggle/main.c
@@ -1,0 +1,31 @@
+#include "gpio_driver.h"
+
+int main(void)
+{
+    GPIO_Handle_t GpioLed, GPIOBtn;
+
+    /* LED setup (PD12) */
+    GpioLed.pGPIOx = GPIOD;
+    GpioLed.GPIO_PinConfig.GPIO_PinNumber = GPIO_PIN_NO_12;
+    GpioLed.GPIO_PinConfig.GPIO_PinMode = GPIO_MODE_OUT;
+    GpioLed.GPIO_PinConfig.GPIO_PinPuPdControl = GPIO_NO_PUPD;
+
+    GPIO_Init(&GpioLed);
+
+    /* Button setup (PA0) */
+    GPIOBtn.pGPIOx = GPIOA;
+    GPIOBtn.GPIO_PinConfig.GPIO_PinNumber = GPIO_PIN_NO_0;
+    GPIOBtn.GPIO_PinConfig.GPIO_PinMode = GPIO_MODE_IN;
+    GPIOBtn.GPIO_PinConfig.GPIO_PinPuPdControl = GPIO_NO_PUPD;
+
+    GPIO_Init(&GPIOBtn);
+
+    while (1) {
+        if (GPIO_ReadFromInputPin(GPIOA, GPIO_PIN_NO_0)) {
+            for (int i = 0; i < 500000; i++); /* crude delay before toggle (debounce) */
+            GPIO_ToggleOutputPin(GPIOD, GPIO_PIN_NO_12);
+        }
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `ManualGPIO_Toggle` example showing a simple button-controlled LED toggle
- implement custom register definitions and GPIO driver

## Testing
- `gcc -c ManualGPIO_Toggle/Drivers/Src/gpio_driver.c -IManualGPIO_Toggle/Drivers/Inc`
- `gcc -c ManualGPIO_Toggle/main.c -IManualGPIO_Toggle/Drivers/Inc`


------
https://chatgpt.com/codex/tasks/task_e_685c96f628708333919b24bea631d85d