### PR TITLE
Improve SPI example with NSS handling

### DIFF
--- a/SPI_Hello/Drivers/Inc/spi_driver.h
+++ b/SPI_Hello/Drivers/Inc/spi_driver.h
@@ -72,6 +72,7 @@ void    SPI_SendData(SPI_RegDef_t*, uint8_t*, uint32_t);
 void    SPI_ReceiveData(SPI_RegDef_t*, uint8_t*, uint32_t);
 void    SPI_PeripheralControl(SPI_RegDef_t*, uint8_t);
 void    SPI_SSIConfig(SPI_RegDef_t*, uint8_t);
+void    SPI_SSOEConfig(SPI_RegDef_t*, uint8_t);
 void    SPI_IRQConfig(uint8_t, uint8_t);
 void    SPI_IRQPriorityConfig(uint8_t, uint8_t);
 void    SPI_IRQHandling(SPI_Handle_t*);

--- a/SPI_Hello/Drivers/Inc/stm32f4xx_custom.h
+++ b/SPI_Hello/Drivers/Inc/stm32f4xx_custom.h
@@ -51,6 +51,9 @@ typedef struct {
 #define SPI2    ((SPI_RegDef_t*)(APB1PERIPH_BASE + 0x3800))
 #define SPI3    ((SPI_RegDef_t*)(APB1PERIPH_BASE + 0x3C00))
 
+/* SPI_CR2 bits */
+#define SPI_CR2_SSOE 2U
+
 /* ==== GENERIC ==== */
 #define ENABLE   1
 #define DISABLE  0

--- a/SPI_Hello/Drivers/Src/spi_driver.c
+++ b/SPI_Hello/Drivers/Src/spi_driver.c
@@ -83,6 +83,12 @@ void SPI_SSIConfig(SPI_RegDef_t *pSPIx, uint8_t EnOrDi){
     else       pSPIx->CR1 &= ~(1<<8);
 }
 
+/* SSOE for HW NSS management */
+void SPI_SSOEConfig(SPI_RegDef_t *pSPIx, uint8_t EnOrDi){
+    if(EnOrDi) pSPIx->CR2 |=  (1U << SPI_CR2_SSOE);
+    else       pSPIx->CR2 &= ~(1U << SPI_CR2_SSOE);
+}
+
 /* IRQ stubs */
 void SPI_IRQConfig(uint8_t IRQ, uint8_t EnOrDi){}
 void SPI_IRQPriorityConfig(uint8_t IRQ, uint8_t Prio){}

--- a/SPI_Hello/main.c
+++ b/SPI_Hello/main.c
@@ -2,51 +2,78 @@
 #include "gpio_driver.h"
 #include "spi_driver.h"
 
-/* small delay */
+/* ~200 ms delay (crude debounce) */
 static void delay(void){
-    for(volatile uint32_t i=0;i<300000;i++);
+    for(volatile uint32_t i=0;i<500000;i++);
 }
 
-/* PB12-PB15 -> SPI2 AF5 */
-void SPI2_GPIOInits(void){
-    GPIO_Handle_t h = {0};
-    h.pGPIOx = GPIOB;
-    h.GPIO_PinConfig.GPIO_PinMode      = GPIO_MODE_ALTFN;
-    h.GPIO_PinConfig.GPIO_PinAltFunMode= 5;
-    h.GPIO_PinConfig.GPIO_PinOPType    = GPIO_OP_TYPE_PP;
-    h.GPIO_PinConfig.GPIO_PinPuPdControl=GPIO_NO_PUPD;
-    h.GPIO_PinConfig.GPIO_PinSpeed     = GPIO_SPEED_FAST;
+/* PA0 button input */
+static void GPIO_ButtonInit(void){
+    GPIO_Handle_t btn = {0};
+    btn.pGPIOx                             = GPIOA;
+    btn.GPIO_PinConfig.GPIO_PinNumber      = 0;
+    btn.GPIO_PinConfig.GPIO_PinMode        = GPIO_MODE_IN;
+    btn.GPIO_PinConfig.GPIO_PinSpeed       = GPIO_SPEED_FAST;
+    btn.GPIO_PinConfig.GPIO_PinPuPdControl = GPIO_NO_PUPD;
 
-    for(uint8_t pin=12; pin<=15; pin++){
-        h.GPIO_PinConfig.GPIO_PinNumber = pin;
-        GPIO_Init(&h);
-    }
+    GPIO_PeriClockControl(GPIOA, ENABLE);
+    GPIO_Init(&btn);
 }
 
-/* SPI2 as master, full-duplex, fPCLK/8, 8-bit, CPOL=0, CPHA=0, SSM=1 */
-void SPI2_Inits(void){
+/* PB12=NSS, PB13=SCLK, PB15=MOSI */
+static void SPI2_GPIOInits(void){
+    GPIO_Handle_t sp = {0};
+    sp.pGPIOx                             = GPIOB;
+    sp.GPIO_PinConfig.GPIO_PinMode        = GPIO_MODE_ALTFN;
+    sp.GPIO_PinConfig.GPIO_PinAltFunMode  = 5;
+    sp.GPIO_PinConfig.GPIO_PinSpeed       = GPIO_SPEED_FAST;
+    sp.GPIO_PinConfig.GPIO_PinOPType      = GPIO_OP_TYPE_PP;
+    sp.GPIO_PinConfig.GPIO_PinPuPdControl = GPIO_NO_PUPD;
+
+    sp.GPIO_PinConfig.GPIO_PinNumber = 12; // NSS
+    GPIO_Init(&sp);
+    sp.GPIO_PinConfig.GPIO_PinNumber = 13; // SCLK
+    GPIO_Init(&sp);
+    sp.GPIO_PinConfig.GPIO_PinNumber = 15; // MOSI
+    GPIO_Init(&sp);
+}
+
+static void SPI2_Inits(void){
     SPI_Handle_t hspi = {0};
-    hspi.pSPIx = SPI2;
+    hspi.pSPIx                    = SPI2;
     hspi.SPIConfig.SPI_DeviceMode = SPI_DEVICE_MODE_MASTER;
     hspi.SPIConfig.SPI_BusConfig  = SPI_BUSCONFIG_FD;
     hspi.SPIConfig.SPI_SclkSpeed  = SPI_SCLK_SPEED_DIV8;
     hspi.SPIConfig.SPI_DFF        = SPI_DFF_8BIT;
     hspi.SPIConfig.SPI_CPOL       = SPI_CPOL_LOW;
     hspi.SPIConfig.SPI_CPHA       = SPI_CPHA_LOW;
-    hspi.SPIConfig.SPI_SSM        = SPI_SSM_ENABLE;
+    hspi.SPIConfig.SPI_SSM        = SPI_SSM_DISABLE;   // HW NSS
     SPI_Init(&hspi);
 }
 
-int main(void){
-    char msg[] = "HELLO";
+int main(void)
+{
+    char user_data[] = "Hello world";
+
+    GPIO_ButtonInit();
     SPI2_GPIOInits();
     SPI2_Inits();
-    SPI_SSIConfig(SPI2, ENABLE);
-    SPI_PeripheralControl(SPI2, ENABLE);
 
-    while(1){
-        SPI_SendData(SPI2, (uint8_t*)msg, strlen(msg));
-        delay();
+    SPI_SSOEConfig(SPI2, ENABLE); // enable HW NSS output
+
+    while (1)
+    {
+        while (!GPIO_ReadFromInputPin(GPIOA, 0)); // wait press
+        delay();                                  // debounce
+
+        SPI_PeripheralControl(SPI2, ENABLE);      // NSS low
+
+        uint8_t dataLen = strlen(user_data);      // length byte
+        SPI_SendData(SPI2, &dataLen, 1);
+        SPI_SendData(SPI2, (uint8_t*)user_data, dataLen); // payload
+
+        while (SPI_GetFlagStatus(SPI2, SPI_BUSY_FLAG));   // wait idle
+        SPI_PeripheralControl(SPI2, DISABLE);     // NSS high
     }
     return 0;
 }


### PR DESCRIPTION
## Summary
- add SPI_CR2_SSOE constant for hardware NSS control
- expose SPI_SSOEConfig API and implement it in the driver
- update the SPI demo to use a button and length-prefixed transfers

## Testing
- `arm-none-eabi-gcc --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f221a8234833389d17e218b1f37a4