### PR TITLE
Add I2C master transmit example

### DIFF
--- a/I2C_Master_Send/Drivers/inc/stm32f407xx.h
+++ b/I2C_Master_Send/Drivers/inc/stm32f407xx.h
@@ -1,0 +1,74 @@
+#ifndef STM32F407XX_H
+#define STM32F407XX_H
+
+#include <stdint.h>
+
+/* =================== BASE ADDRESSES =================== */
+#define PERIPH_BASE        0x40000000U
+#define AHB1PERIPH_BASE    (PERIPH_BASE + 0x00020000U)
+#define APB1PERIPH_BASE    (PERIPH_BASE + 0x00000000U)
+#define APB2PERIPH_BASE    (PERIPH_BASE + 0x00010000U)
+
+/* ======================= GPIO ========================= */
+typedef struct {
+    volatile uint32_t MODER;
+    volatile uint32_t OTYPER;
+    volatile uint32_t OSPEEDR;
+    volatile uint32_t PUPDR;
+    volatile uint32_t IDR;
+    volatile uint32_t ODR;
+    volatile uint32_t BSRR;
+    volatile uint32_t LCKR;
+    volatile uint32_t AFR[2];
+} GPIO_RegDef_t;
+
+#define GPIOA ((GPIO_RegDef_t*)(AHB1PERIPH_BASE + 0x0000))
+#define GPIOB ((GPIO_RegDef_t*)(AHB1PERIPH_BASE + 0x0400))
+#define GPIOC ((GPIO_RegDef_t*)(AHB1PERIPH_BASE + 0x0800))
+#define GPIOD ((GPIO_RegDef_t*)(AHB1PERIPH_BASE + 0x0C00))
+
+/* ======================== RCC ========================= */
+typedef struct {
+    volatile uint32_t CR;
+    volatile uint32_t PLLCFGR;
+    volatile uint32_t CFGR;
+    volatile uint32_t CIR;
+    volatile uint32_t AHB1RSTR;
+    volatile uint32_t AHB2RSTR;
+    volatile uint32_t AHB3RSTR;
+    volatile uint32_t __RES0;
+    volatile uint32_t APB1RSTR;
+    volatile uint32_t APB2RSTR;
+    volatile uint32_t __RES1[2];
+    volatile uint32_t AHB1ENR;
+    volatile uint32_t AHB2ENR;
+    volatile uint32_t AHB3ENR;
+    volatile uint32_t __RES2;
+    volatile uint32_t APB1ENR;
+    volatile uint32_t APB2ENR;
+    volatile uint32_t __RES3[2];
+} RCC_RegDef_t;
+
+#define RCC ((RCC_RegDef_t*)(AHB1PERIPH_BASE + 0x3800))
+
+/* ======================== I2C ========================= */
+typedef struct {
+    volatile uint32_t CR1;
+    volatile uint32_t CR2;
+    volatile uint32_t OAR1;
+    volatile uint32_t OAR2;
+    volatile uint32_t DR;
+    volatile uint32_t SR1;
+    volatile uint32_t SR2;
+    volatile uint32_t CCR;
+    volatile uint32_t TRISE;
+    volatile uint32_t FLTR;
+} I2C_RegDef_t;
+
+#define I2C1 ((I2C_RegDef_t*)(APB1PERIPH_BASE + 0x5400))
+
+/* ====================== GENERIC ======================= */
+#define ENABLE  1
+#define DISABLE 0
+
+#endif // STM32F407XX_H

--- a/I2C_Master_Send/Drivers/inc/stm32f407xx_gpio_driver.h
+++ b/I2C_Master_Send/Drivers/inc/stm32f407xx_gpio_driver.h
@@ -1,0 +1,61 @@
+#ifndef STM32F407XX_GPIO_DRIVER_H
+#define STM32F407XX_GPIO_DRIVER_H
+
+#include "stm32f407xx.h"
+#include <stdint.h>
+
+#define GPIO_MODE_IN      0
+#define GPIO_MODE_OUT     1
+#define GPIO_MODE_ALTFN   2
+#define GPIO_MODE_ANALOG  3
+
+#define GPIO_OP_TYPE_PP   0
+#define GPIO_OP_TYPE_OD   1
+
+#define GPIO_SPEED_LOW    0
+#define GPIO_SPEED_MEDIUM 1
+#define GPIO_SPEED_FAST   2
+#define GPIO_SPEED_HIGH   3
+
+#define GPIO_NO_PUPD      0
+#define GPIO_PIN_PU       1
+#define GPIO_PIN_PD       2
+
+#define GPIO_PIN_NO_0     0
+#define GPIO_PIN_NO_1     1
+#define GPIO_PIN_NO_2     2
+#define GPIO_PIN_NO_3     3
+#define GPIO_PIN_NO_4     4
+#define GPIO_PIN_NO_5     5
+#define GPIO_PIN_NO_6     6
+#define GPIO_PIN_NO_7     7
+#define GPIO_PIN_NO_8     8
+#define GPIO_PIN_NO_9     9
+#define GPIO_PIN_NO_10    10
+#define GPIO_PIN_NO_11    11
+#define GPIO_PIN_NO_12    12
+#define GPIO_PIN_NO_13    13
+#define GPIO_PIN_NO_14    14
+#define GPIO_PIN_NO_15    15
+
+typedef struct {
+    uint8_t GPIO_PinNumber;
+    uint8_t GPIO_PinMode;
+    uint8_t GPIO_PinSpeed;
+    uint8_t GPIO_PinPuPdControl;
+    uint8_t GPIO_PinOPType;
+    uint8_t GPIO_PinAltFunMode;
+} GPIO_PinConfig_t;
+
+typedef struct {
+    GPIO_RegDef_t *pGPIOx;
+    GPIO_PinConfig_t GPIO_PinConfig;
+} GPIO_Handle_t;
+
+void GPIO_PeriClockControl(GPIO_RegDef_t *pGPIOx, uint8_t EnOrDi);
+void GPIO_Init(GPIO_Handle_t *pGPIOHandle);
+void GPIO_DeInit(GPIO_RegDef_t *pGPIOx);
+uint8_t GPIO_ReadFromInputPin(GPIO_RegDef_t *pGPIOx, uint8_t PinNumber);
+void GPIO_ToggleOutputPin(GPIO_RegDef_t *pGPIOx, uint8_t PinNumber);
+
+#endif // STM32F407XX_GPIO_DRIVER_H

--- a/I2C_Master_Send/Drivers/inc/stm32f407xx_i2c_driver.h
+++ b/I2C_Master_Send/Drivers/inc/stm32f407xx_i2c_driver.h
@@ -1,0 +1,62 @@
+#ifndef STM32F407XX_I2C_DRIVER_H
+#define STM32F407XX_I2C_DRIVER_H
+
+#include "stm32f407xx.h"
+#include <stdint.h>
+
+/* CR1 */
+#define I2C_CR1_PE     0
+#define I2C_CR1_START  8
+#define I2C_CR1_STOP   9
+#define I2C_CR1_ACK    10
+#define I2C_CR1_SWRST  15
+
+/* SR1 */
+#define I2C_SR1_SB     0
+#define I2C_SR1_ADDR   1
+#define I2C_SR1_BTF    2
+#define I2C_SR1_RXNE   6
+#define I2C_SR1_TXE    7
+
+/* SR2 */
+#define I2C_SR2_MSL    0
+#define I2C_SR2_BUSY   1
+
+/* Flags */
+#define I2C_FLAG_SB    (1U<<I2C_SR1_SB)
+#define I2C_FLAG_ADDR  (1U<<I2C_SR1_ADDR)
+#define I2C_FLAG_BTF   (1U<<I2C_SR1_BTF)
+#define I2C_FLAG_TXE   (1U<<I2C_SR1_TXE)
+
+/* Config */
+#define I2C_SCL_SPEED_SM   100000U
+#define I2C_ACK_ENABLE     1
+#define I2C_ACK_DISABLE    0
+#define I2C_FM_DUTY_2      0
+
+typedef struct {
+    uint32_t I2C_SCLSpeed;
+    uint8_t  I2C_DeviceAddress;
+    uint8_t  I2C_ACKControl;
+    uint8_t  I2C_FMDutyCycle;
+} I2C_Config_t;
+
+typedef struct {
+    I2C_RegDef_t *pI2Cx;
+    I2C_Config_t  I2CConfig;
+} I2C_Handle_t;
+
+/* APIs */
+void I2C_PeriClockControl(I2C_RegDef_t *pI2Cx, uint8_t EnOrDi);
+void I2C_Init(I2C_Handle_t *pI2CHandle);
+
+void I2C_GenerateStartCondition(I2C_RegDef_t *pI2Cx);
+void I2C_GenerateStopCondition(I2C_RegDef_t *pI2Cx);
+
+void I2C_MasterSendData(I2C_Handle_t *pI2CHandle,
+                        uint8_t *pTxBuffer,
+                        uint32_t Len,
+                        uint8_t SlaveAddr,
+                        uint8_t Sr);
+
+#endif

--- a/I2C_Master_Send/Drivers/src/stm32f407xx_gpio_driver.c
+++ b/I2C_Master_Send/Drivers/src/stm32f407xx_gpio_driver.c
@@ -1,0 +1,57 @@
+#include "stm32f407xx_gpio_driver.h"
+
+void GPIO_PeriClockControl(GPIO_RegDef_t *pGPIOx, uint8_t EnOrDi){
+    if (pGPIOx == GPIOA) {
+        EnOrDi ? (RCC->AHB1ENR |= (1<<0))
+               : (RCC->AHB1ENR &= ~(1<<0));
+    } else if (pGPIOx == GPIOB){
+        EnOrDi ? (RCC->AHB1ENR |= (1<<1))
+               : (RCC->AHB1ENR &= ~(1<<1));
+    } else if (pGPIOx == GPIOC){
+        EnOrDi ? (RCC->AHB1ENR |= (1<<2))
+               : (RCC->AHB1ENR &= ~(1<<2));
+    } else if (pGPIOx == GPIOD){
+        EnOrDi ? (RCC->AHB1ENR |= (1<<3))
+               : (RCC->AHB1ENR &= ~(1<<3));
+    }
+}
+
+void GPIO_Init(GPIO_Handle_t *pH){
+    uint8_t pin  = pH->GPIO_PinConfig.GPIO_PinNumber;
+    uint8_t mode = pH->GPIO_PinConfig.GPIO_PinMode;
+
+    GPIO_PeriClockControl(pH->pGPIOx, ENABLE);
+
+    pH->pGPIOx->MODER   &= ~(0x3U << (2*pin));
+    pH->pGPIOx->MODER   |=  (mode  << (2*pin));
+
+    pH->pGPIOx->OTYPER  &= ~(1U << pin);
+    pH->pGPIOx->OTYPER  |=  (pH->GPIO_PinConfig.GPIO_PinOPType << pin);
+
+    pH->pGPIOx->OSPEEDR &= ~(0x3U << (2*pin));
+    pH->pGPIOx->OSPEEDR |=  (pH->GPIO_PinConfig.GPIO_PinSpeed << (2*pin));
+
+    pH->pGPIOx->PUPDR   &= ~(0x3U << (2*pin));
+    pH->pGPIOx->PUPDR   |=  (pH->GPIO_PinConfig.GPIO_PinPuPdControl << (2*pin));
+
+    if (mode == GPIO_MODE_ALTFN) {
+        uint8_t idx = pin/8, pos = (pin%8)*4;
+        pH->pGPIOx->AFR[idx] &= ~(0xFU << pos);
+        pH->pGPIOx->AFR[idx] |=  (pH->GPIO_PinConfig.GPIO_PinAltFunMode << pos);
+    }
+}
+
+void GPIO_DeInit(GPIO_RegDef_t *pGPIOx){
+    if(pGPIOx==GPIOA){ RCC->AHB1RSTR |= (1<<0); RCC->AHB1RSTR &= ~(1<<0); }
+    else if(pGPIOx==GPIOB){ RCC->AHB1RSTR |= (1<<1); RCC->AHB1RSTR &= ~(1<<1); }
+    else if(pGPIOx==GPIOC){ RCC->AHB1RSTR |= (1<<2); RCC->AHB1RSTR &= ~(1<<2); }
+    else if(pGPIOx==GPIOD){ RCC->AHB1RSTR |= (1<<3); RCC->AHB1RSTR &= ~(1<<3); }
+}
+
+uint8_t GPIO_ReadFromInputPin(GPIO_RegDef_t *pGPIOx, uint8_t PinNumber){
+    return (uint8_t)((pGPIOx->IDR >> PinNumber) & 0x1);
+}
+
+void GPIO_ToggleOutputPin(GPIO_RegDef_t *pGPIOx, uint8_t PinNumber){
+    pGPIOx->ODR ^= (1 << PinNumber);
+}

--- a/I2C_Master_Send/Drivers/src/stm32f407xx_i2c_driver.c
+++ b/I2C_Master_Send/Drivers/src/stm32f407xx_i2c_driver.c
@@ -1,0 +1,61 @@
+#include "stm32f407xx_i2c_driver.h"
+
+/* Assume PCLK1 = 16 MHz */
+static uint32_t RCC_GetPCLK1Value(void){ return 16000000U; }
+
+static void I2C_ExecuteAddressPhaseWrite(I2C_RegDef_t *p, uint8_t addr){
+    p->DR = (addr<<1) & ~1;
+}
+
+static void I2C_ClearADDRFlag(I2C_Handle_t *h){
+    volatile uint32_t d;
+    d = h->pI2Cx->SR1; (void)d;
+    d = h->pI2Cx->SR2; (void)d;
+}
+
+static uint8_t I2C_GetFlagStatus(I2C_RegDef_t *p, uint32_t Flag){
+    if(Flag & 0xFFFF0000) return (p->SR2 & Flag) ? 1 : 0;
+    else return (p->SR1 & Flag) ? 1 : 0;
+}
+
+void I2C_PeriClockControl(I2C_RegDef_t *p, uint8_t En){
+    if(p==I2C1) (En)? (RCC->APB1ENR|=(1<<21)) : (RCC->APB1ENR&=~(1<<21));
+}
+
+void I2C_Init(I2C_Handle_t *h){
+    I2C_PeriClockControl(h->pI2Cx,1);
+    h->pI2Cx->CR1 &= ~(1<<I2C_CR1_PE);
+
+    uint32_t pclk1 = RCC_GetPCLK1Value();
+    uint32_t fMHz  = pclk1/1000000U;
+    h->pI2Cx->CR2  = (fMHz & 0x3F);
+
+    h->pI2Cx->OAR1 = (1<<14) | ((h->I2CConfig.I2C_DeviceAddress & 0x7F)<<1);
+
+    uint16_t ccr = (uint16_t)(pclk1/(2*h->I2CConfig.I2C_SCLSpeed));
+    h->pI2Cx->CCR = ccr;
+    h->pI2Cx->TRISE = fMHz+1;
+
+    if(h->I2CConfig.I2C_ACKControl) h->pI2Cx->CR1|=(1<<I2C_CR1_ACK);
+
+    h->pI2Cx->CR1|=(1<<I2C_CR1_PE);
+}
+
+void I2C_GenerateStartCondition(I2C_RegDef_t *p){ p->CR1 |= (1<<I2C_CR1_START); }
+void I2C_GenerateStopCondition(I2C_RegDef_t *p){ p->CR1 |= (1<<I2C_CR1_STOP); }
+
+void I2C_MasterSendData(I2C_Handle_t *h,uint8_t *tx,uint32_t len,uint8_t addr,uint8_t sr){
+    I2C_GenerateStartCondition(h->pI2Cx);
+    while(!I2C_GetFlagStatus(h->pI2Cx,I2C_FLAG_SB));
+    I2C_ExecuteAddressPhaseWrite(h->pI2Cx,addr);
+    while(!I2C_GetFlagStatus(h->pI2Cx,I2C_FLAG_ADDR));
+    I2C_ClearADDRFlag(h);
+
+    while(len--){
+        while(!I2C_GetFlagStatus(h->pI2Cx,I2C_FLAG_TXE));
+        h->pI2Cx->DR=*tx++;
+    }
+    while(!I2C_GetFlagStatus(h->pI2Cx,I2C_FLAG_TXE));
+    while(!I2C_GetFlagStatus(h->pI2Cx,I2C_FLAG_BTF));
+    if(sr==0) I2C_GenerateStopCondition(h->pI2Cx);
+}

--- a/I2C_Master_Send/Makefile
+++ b/I2C_Master_Send/Makefile
@@ -1,0 +1,29 @@
+CC=arm-none-eabi-gcc
+OBJCOPY=arm-none-eabi-objcopy
+
+TARGET=I2C_Master_Send
+BUILD=build
+
+MCU=-mcpu=cortex-m4 -mthumb
+CFLAGS=$(MCU) -O0 -g -Wall -ffunction-sections -fdata-sections -I./Drivers/inc -DSTM32F407xx
+
+SRCS=main.c      Drivers/src/stm32f407xx_gpio_driver.c      Drivers/src/stm32f407xx_i2c_driver.c
+
+LDSCRIPT=STM32F407VGTx_FLASH.ld
+
+OBJ=$(SRCS:%.c=$(BUILD)/%.o)
+
+all: $(BUILD)/$(TARGET).elf
+
+$(BUILD)/%.o: %.c
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(BUILD)/$(TARGET).elf: $(OBJ)
+	$(CC) $(CFLAGS) -T$(LDSCRIPT) $(OBJ) -o $@
+	$(OBJCOPY) -O binary $@ $(BUILD)/$(TARGET).bin
+
+clean:
+	rm -rf $(BUILD)
+
+.PHONY: all clean

--- a/I2C_Master_Send/main.c
+++ b/I2C_Master_Send/main.c
@@ -1,0 +1,58 @@
+#include <string.h>
+#include "Drivers/inc/stm32f407xx_gpio_driver.h"
+#include "Drivers/inc/stm32f407xx_i2c_driver.h"
+
+static void delay(volatile uint32_t t){ while(t--) __asm__("nop"); }
+
+/* I2C1: PB6=SCL, PB9=SDA */
+static void I2C1_GPIO_Init(void){
+    GPIO_Handle_t g;
+    GPIO_PeriClockControl(GPIOB,ENABLE);
+
+    g.pGPIOx=GPIOB;
+    g.GPIO_PinConfig.GPIO_PinMode=GPIO_MODE_ALTFN;
+    g.GPIO_PinConfig.GPIO_PinOPType=GPIO_OP_TYPE_OD;
+    g.GPIO_PinConfig.GPIO_PinSpeed=GPIO_SPEED_FAST;
+    g.GPIO_PinConfig.GPIO_PinPuPdControl=GPIO_PIN_PU;
+    g.GPIO_PinConfig.GPIO_PinAltFunMode=4;
+
+    g.GPIO_PinConfig.GPIO_PinNumber=GPIO_PIN_NO_6; GPIO_Init(&g); // SCL
+    g.GPIO_PinConfig.GPIO_PinNumber=GPIO_PIN_NO_9; GPIO_Init(&g); // SDA
+}
+
+/* PA0 button */
+static void Button_Init(void){
+    GPIO_Handle_t btn;
+    GPIO_PeriClockControl(GPIOA,ENABLE);
+    btn.pGPIOx=GPIOA;
+    btn.GPIO_PinConfig.GPIO_PinNumber=GPIO_PIN_NO_0;
+    btn.GPIO_PinConfig.GPIO_PinMode=GPIO_MODE_IN;
+    btn.GPIO_PinConfig.GPIO_PinPuPdControl=GPIO_NO_PUPD;
+    GPIO_Init(&btn);
+}
+
+int main(void){
+    I2C1_GPIO_Init();
+    Button_Init();
+
+    I2C_Handle_t hi2c1;
+    memset(&hi2c1,0,sizeof(hi2c1));
+    hi2c1.pI2Cx=I2C1;
+    hi2c1.I2CConfig.I2C_SCLSpeed=I2C_SCL_SPEED_SM;
+    hi2c1.I2CConfig.I2C_DeviceAddress=0x61;
+    hi2c1.I2CConfig.I2C_ACKControl=I2C_ACK_ENABLE;
+    hi2c1.I2CConfig.I2C_FMDutyCycle=I2C_FM_DUTY_2;
+
+    I2C_Init(&hi2c1);
+
+    const uint8_t SLAVE_ADDR=0x3C;       // target slave address
+    const char msg[]="Hello I2C Slave!";
+
+    while(1){
+        if(GPIO_ReadFromInputPin(GPIOA,GPIO_PIN_NO_0)){
+            I2C_MasterSendData(&hi2c1,(uint8_t*)msg,strlen(msg),SLAVE_ADDR,0);
+            delay(200000);
+            while(GPIO_ReadFromInputPin(GPIOA,GPIO_PIN_NO_0));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add minimal STM32F407 I2C driver and supporting register definitions
- create example that transmits a string over I2C1 on button press
- supply Makefile for building with the arm-none-eabi toolchain

## Testing
- `gcc -I I2C_Master_Send/Drivers/inc -c I2C_Master_Send/main.c I2C_Master_Send/Drivers/src/stm32f407xx_gpio_driver.c I2C_Master_Send/Drivers/src/stm32f407xx_i2c_driver.c`
- `make` *(fails: arm-none-eabi-gcc: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a3df38de508333ac25493d8ee7cde7