### PR TITLE
Add I2C interrupt-driven example

### DIFF
--- a/I2C_IRQ/Drivers/inc/stm32f407xx.h
+++ b/I2C_IRQ/Drivers/inc/stm32f407xx.h
@@ -1,0 +1,72 @@
+#ifndef STM32F407XX_H
+#define STM32F407XX_H
+
+#include <stdint.h>
+
+#define __IO volatile
+
+/* ================= Cortex-M4 NVIC ================= */
+typedef struct {
+  __IO uint32_t ISER[8];      uint32_t RESERVED0[24];
+  __IO uint32_t ICER[8];      uint32_t RESERVED1[24];
+  __IO uint32_t ISPR[8];      uint32_t RESERVED2[24];
+  __IO uint32_t ICPR[8];      uint32_t RESERVED3[24];
+  __IO uint32_t IABR[8];      uint32_t RESERVED4[56];
+  __IO uint8_t  IPR[240];
+} NVIC_Type;
+#define NVIC ((NVIC_Type*)0xE000E100UL)
+
+/* ================== Base addresses ================= */
+#define PERIPH_BASE        0x40000000UL
+#define APB1PERIPH_BASE    (PERIPH_BASE + 0x00000000UL)
+#define APB2PERIPH_BASE    (PERIPH_BASE + 0x00010000UL)
+#define AHB1PERIPH_BASE    (PERIPH_BASE + 0x00020000UL)
+
+/* ================== RCC ================== */
+typedef struct {
+  __IO uint32_t CR;       __IO uint32_t PLLCFGR; __IO uint32_t CFGR;   __IO uint32_t CIR;
+  __IO uint32_t AHB1RSTR; __IO uint32_t AHB2RSTR;__IO uint32_t AHB3RSTR; uint32_t RESERVED0;
+  __IO uint32_t APB1RSTR; __IO uint32_t APB2RSTR; uint32_t RESERVED1[2];
+  __IO uint32_t AHB1ENR;  __IO uint32_t AHB2ENR; __IO uint32_t AHB3ENR;  uint32_t RESERVED2;
+  __IO uint32_t APB1ENR;  __IO uint32_t APB2ENR; uint32_t RESERVED3[2];
+  __IO uint32_t AHB1LPENR;__IO uint32_t AHB2LPENR;__IO uint32_t AHB3LPENR;uint32_t RESERVED4;
+  __IO uint32_t APB1LPENR;__IO uint32_t APB2LPENR;uint32_t RESERVED5[2];
+  __IO uint32_t BDCR;     __IO uint32_t CSR;      uint32_t RESERVED6[2];
+  __IO uint32_t SSCGR;    __IO uint32_t PLLI2SCFGR; __IO uint32_t PLLSAICFGR;
+  __IO uint32_t DCKCFGR;  __IO uint32_t CKGATENR;   __IO uint32_t DCKCFGR2;
+} RCC_RegDef_t;
+#define RCC ((RCC_RegDef_t*)(AHB1PERIPH_BASE + 0x3800UL))
+
+/* ================== GPIO ================== */
+typedef struct {
+  __IO uint32_t MODER;   __IO uint32_t OTYPER; __IO uint32_t OSPEEDR; __IO uint32_t PUPDR;
+  __IO uint32_t IDR;     __IO uint32_t ODR;    __IO uint32_t BSRR;    __IO uint32_t LCKR;
+  __IO uint32_t AFR[2];
+} GPIO_RegDef_t;
+#define GPIOA ((GPIO_RegDef_t*)(AHB1PERIPH_BASE + 0x0000UL))
+#define GPIOB ((GPIO_RegDef_t*)(AHB1PERIPH_BASE + 0x0400UL))
+#define GPIOC ((GPIO_RegDef_t*)(AHB1PERIPH_BASE + 0x0800UL))
+
+/* ================== I2C ================== */
+typedef struct {
+  __IO uint32_t CR1;   __IO uint32_t CR2;   __IO uint32_t OAR1;  __IO uint32_t OAR2;
+  __IO uint32_t DR;    __IO uint32_t SR1;   __IO uint32_t SR2;   __IO uint32_t CCR;
+  __IO uint32_t TRISE; __IO uint32_t FLTR;
+} I2C_RegDef_t;
+#define I2C1 ((I2C_RegDef_t*)(APB1PERIPH_BASE + 0x5400UL))
+#define I2C2 ((I2C_RegDef_t*)(APB1PERIPH_BASE + 0x5800UL))
+#define I2C3 ((I2C_RegDef_t*)(APB1PERIPH_BASE + 0x5C00UL))
+
+/* ================== RCC clock enable bits ================== */
+#define RCC_AHB1ENR_GPIOAEN   (1U<<0)
+#define RCC_AHB1ENR_GPIOBEN   (1U<<1)
+#define RCC_AHB1ENR_GPIOCEN   (1U<<2)
+
+#define RCC_APB1ENR_I2C1EN    (1U<<21)
+#define RCC_APB1ENR_I2C2EN    (1U<<22)
+#define RCC_APB1ENR_I2C3EN    (1U<<23)
+
+#define ENABLE  1U
+#define DISABLE 0U
+
+#endif /* STM32F407XX_H */

--- a/I2C_IRQ/Drivers/inc/stm32f407xx_gpio_driver.h
+++ b/I2C_IRQ/Drivers/inc/stm32f407xx_gpio_driver.h
@@ -1,0 +1,57 @@
+#ifndef STM32F407XX_GPIO_DRIVER_H
+#define STM32F407XX_GPIO_DRIVER_H
+
+#include "stm32f407xx.h"
+
+#define GPIO_PIN_0  0U
+#define GPIO_PIN_1  1U
+#define GPIO_PIN_2  2U
+#define GPIO_PIN_3  3U
+#define GPIO_PIN_4  4U
+#define GPIO_PIN_5  5U
+#define GPIO_PIN_6  6U
+#define GPIO_PIN_7  7U
+#define GPIO_PIN_8  8U
+#define GPIO_PIN_9  9U
+#define GPIO_PIN_10 10U
+#define GPIO_PIN_11 11U
+#define GPIO_PIN_12 12U
+#define GPIO_PIN_13 13U
+#define GPIO_PIN_14 14U
+#define GPIO_PIN_15 15U
+
+#define GPIO_MODE_IN      0U
+#define GPIO_MODE_OUT     1U
+#define GPIO_MODE_ALTFN   2U
+#define GPIO_MODE_ANALOG  3U
+
+#define GPIO_OP_TYPE_PP   0U
+#define GPIO_OP_TYPE_OD   1U
+
+#define GPIO_SPEED_LOW    0U
+#define GPIO_SPEED_MED    1U
+#define GPIO_SPEED_HIGH   2U
+#define GPIO_SPEED_VHIGH  3U
+
+#define GPIO_NO_PUPD      0U
+#define GPIO_PIN_PU       1U
+#define GPIO_PIN_PD       2U
+
+typedef struct {
+  uint8_t GPIO_PinNumber;
+  uint8_t GPIO_PinMode;
+  uint8_t GPIO_PinSpeed;
+  uint8_t GPIO_PinPuPdControl;
+  uint8_t GPIO_PinOPType;
+  uint8_t GPIO_PinAltFunMode;
+} GPIO_PinConfig_t;
+
+typedef struct {
+  GPIO_RegDef_t *pGPIOx;
+  GPIO_PinConfig_t GPIO_PinConfig;
+} GPIO_Handle_t;
+
+void GPIO_PeriClockControl(GPIO_RegDef_t *pGPIOx, uint8_t En);
+void GPIO_Init(GPIO_Handle_t *pGPIOHandle);
+
+#endif

--- a/I2C_IRQ/Drivers/inc/stm32f407xx_i2c_driver.h
+++ b/I2C_IRQ/Drivers/inc/stm32f407xx_i2c_driver.h
@@ -1,0 +1,84 @@
+#ifndef STM32F407XX_I2C_DRIVER_H
+#define STM32F407XX_I2C_DRIVER_H
+
+#include "stm32f407xx.h"
+#include <stdint.h>
+
+#define SET   1U
+#define RESET 0U
+
+#define I2C_SCL_SPEED_SM     100000U
+#define I2C_SCL_SPEED_FM2K   200000U
+#define I2C_SCL_SPEED_FM4K   400000U
+
+#define I2C_ACK_DISABLE      0U
+#define I2C_ACK_ENABLE       1U
+#define I2C_FM_DUTY_2        0U
+#define I2C_FM_DUTY_16_9     1U
+
+#define I2C_READY            0U
+#define I2C_BUSY_IN_RX       1U
+#define I2C_BUSY_IN_TX       2U
+
+#define I2C_EV_TX_CMPLT      1U
+#define I2C_EV_RX_CMPLT      2U
+#define I2C_EV_STOP          3U
+#define I2C_ERROR_BERR       4U
+#define I2C_ERROR_ARLO       5U
+#define I2C_ERROR_AF         6U
+#define I2C_ERROR_OVR        7U
+#define I2C_ERROR_TIMEOUT    8U
+
+#define I2C_FLAG_SB          (1U<<0)
+#define I2C_FLAG_ADDR        (1U<<1)
+#define I2C_FLAG_BTF         (1U<<2)
+#define I2C_FLAG_STOPF       (1U<<4)
+#define I2C_FLAG_RXNE        (1U<<6)
+#define I2C_FLAG_TXE         (1U<<7)
+
+#define I2C_ERR_BERR         (1U<<8)
+#define I2C_ERR_ARLO         (1U<<9)
+#define I2C_ERR_AF           (1U<<10)
+#define I2C_ERR_OVR          (1U<<11)
+#define I2C_ERR_TIMEOUT      (1U<<14)
+
+#define IRQ_NO_I2C1_EV       31U
+#define IRQ_NO_I2C1_ER       32U
+
+typedef struct {
+  uint32_t I2C_SCLSpeed;
+  uint8_t  I2C_DeviceAddress;
+  uint8_t  I2C_ACKControl;
+  uint8_t  I2C_FMDutyCycle;
+} I2C_Config_t;
+
+typedef struct {
+  I2C_RegDef_t *pI2Cx;
+  I2C_Config_t  I2C_Config;
+
+  uint8_t  *pTxBuffer;  uint32_t TxLen;
+  uint8_t  *pRxBuffer;  uint32_t RxLen; uint32_t RxSize;
+  uint8_t   Sr;         uint8_t  TxRxState;
+  uint8_t   DevAddr;
+} I2C_Handle_t;
+
+void I2C_PeriClockControl(I2C_RegDef_t *pI2Cx, uint8_t En);
+void I2C_PeripheralControl(I2C_RegDef_t *pI2Cx, uint8_t En);
+void I2C_Init(I2C_Handle_t *pHandle);
+void I2C_DeInit(I2C_RegDef_t *pI2Cx);
+void I2C_ManageAcking(I2C_RegDef_t *pI2Cx, uint8_t En);
+
+uint8_t I2C_MasterSendDataIT(I2C_Handle_t *pH, uint8_t *pTx, uint32_t Len, uint8_t SlaveAddr, uint8_t Sr);
+uint8_t I2C_MasterReceiveDataIT(I2C_Handle_t *pH, uint8_t *pRx, uint32_t Len, uint8_t SlaveAddr, uint8_t Sr);
+
+void I2C_IRQInterruptConfig(uint8_t IRQNumber, uint8_t En);
+void I2C_IRQPriorityConfig(uint8_t IRQNumber, uint32_t IRQPriority);
+
+void I2C_EV_IRQHandling(I2C_Handle_t *pH);
+void I2C_ER_IRQHandling(I2C_Handle_t *pH);
+
+uint8_t I2C_GetFlagStatus(I2C_RegDef_t *pI2Cx, uint32_t FlagMask);
+
+void I2C_ApplicationEventCallback(I2C_Handle_t *pHandle, uint8_t AppEvent) __attribute__((weak));
+
+#endif

--- a/I2C_IRQ/Drivers/src/stm32f407xx_gpio_driver.c
+++ b/I2C_IRQ/Drivers/src/stm32f407xx_gpio_driver.c
@@ -1,0 +1,45 @@
+#include "stm32f407xx_gpio_driver.h"
+
+void GPIO_PeriClockControl(GPIO_RegDef_t *pGPIOx, uint8_t En)
+{
+    if (En == ENABLE) {
+        if (pGPIOx == GPIOA) RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN;
+        else if (pGPIOx == GPIOB) RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN;
+        else if (pGPIOx == GPIOC) RCC->AHB1ENR |= RCC_AHB1ENR_GPIOCEN;
+    } else {
+        if (pGPIOx == GPIOA) RCC->AHB1ENR &= ~RCC_AHB1ENR_GPIOAEN;
+        else if (pGPIOx == GPIOB) RCC->AHB1ENR &= ~RCC_AHB1ENR_GPIOBEN;
+        else if (pGPIOx == GPIOC) RCC->AHB1ENR &= ~RCC_AHB1ENR_GPIOCEN;
+    }
+}
+
+void GPIO_Init(GPIO_Handle_t *h)
+{
+    GPIO_PeriClockControl(h->pGPIOx, ENABLE);
+
+    uint32_t pin = h->GPIO_PinConfig.GPIO_PinNumber;
+
+    /* Mode */
+    h->pGPIOx->MODER &= ~(0x3U << (2U*pin));
+    h->pGPIOx->MODER |=  ((uint32_t)h->GPIO_PinConfig.GPIO_PinMode << (2U*pin));
+
+    /* Output type */
+    h->pGPIOx->OTYPER &= ~(1U << pin);
+    h->pGPIOx->OTYPER |=  ((uint32_t)h->GPIO_PinConfig.GPIO_PinOPType << pin);
+
+    /* Speed */
+    h->pGPIOx->OSPEEDR &= ~(0x3U << (2U*pin));
+    h->pGPIOx->OSPEEDR |=  ((uint32_t)h->GPIO_PinConfig.GPIO_PinSpeed << (2U*pin));
+
+    /* Pull-up/down */
+    h->pGPIOx->PUPDR &= ~(0x3U << (2U*pin));
+    h->pGPIOx->PUPDR |=  ((uint32_t)h->GPIO_PinConfig.GPIO_PinPuPdControl << (2U*pin));
+
+    /* Alt function (if needed) */
+    if (h->GPIO_PinConfig.GPIO_PinMode == GPIO_MODE_ALTFN) {
+        uint8_t idx = pin / 8U;
+        uint8_t pos = (pin % 8U) * 4U;
+        h->pGPIOx->AFR[idx] &= ~(0xFU << pos);
+        h->pGPIOx->AFR[idx] |=  ((uint32_t)(h->GPIO_PinConfig.GPIO_PinAltFunMode & 0xF) << pos);
+    }
+}

--- a/I2C_IRQ/Drivers/src/stm32f407xx_i2c_driver.c
+++ b/I2C_IRQ/Drivers/src/stm32f407xx_i2c_driver.c
@@ -1,0 +1,176 @@
+#include "stm32f407xx_i2c_driver.h"
+
+/* ======= Private helpers ======= */
+static void I2C_GenerateStart(I2C_RegDef_t *p) { p->CR1 |= (1U<<8); }
+static void I2C_GenerateStop (I2C_RegDef_t *p) { p->CR1 |= (1U<<9); }
+static void I2C_ExecuteAddrPhaseWrite(I2C_RegDef_t *p, uint8_t addr) { p->DR = (uint8_t)((addr<<1)&0xFE); }
+static void I2C_ExecuteAddrPhaseRead (I2C_RegDef_t *p, uint8_t addr) { p->DR = (uint8_t)((addr<<1)|0x01); }
+
+static void I2C_ClearADDRFlag(I2C_Handle_t *h) { (void)h->pI2Cx->SR1; (void)h->pI2Cx->SR2; }
+
+static void I2C_CloseReceiveData(I2C_Handle_t *h) {
+    h->pI2Cx->CR2 &= ~(1U<<10); /* ITBUFEN */
+    h->pI2Cx->CR2 &= ~(1U<<9);  /* ITEVTEN */
+    h->pI2Cx->CR2 &= ~(1U<<8);  /* ITERREN */
+    if (h->I2C_Config.I2C_ACKControl == I2C_ACK_ENABLE) I2C_ManageAcking(h->pI2Cx, ENABLE);
+    h->TxRxState = I2C_READY; h->pRxBuffer = 0; h->RxLen = h->RxSize = 0;
+}
+static void I2C_CloseSendData(I2C_Handle_t *h) {
+    h->pI2Cx->CR2 &= ~(1U<<10); h->pI2Cx->CR2 &= ~(1U<<9); h->pI2Cx->CR2 &= ~(1U<<8);
+    h->TxRxState = I2C_READY; h->pTxBuffer = 0; h->TxLen = 0;
+}
+
+/* If APB1 != 16 MHz, change this to your real PCLK1 value */
+static uint32_t I2C_GetPCLK1Hz(void) { return 16000000UL; }
+
+/* ======= Public APIs ======= */
+void I2C_PeriClockControl(I2C_RegDef_t *p, uint8_t En) {
+    if (En) {
+        if (p==I2C1) RCC->APB1ENR |= RCC_APB1ENR_I2C1EN;
+        else if (p==I2C2) RCC->APB1ENR |= RCC_APB1ENR_I2C2EN;
+        else if (p==I2C3) RCC->APB1ENR |= RCC_APB1ENR_I2C3EN;
+    } else {
+        if (p==I2C1) RCC->APB1ENR &= ~RCC_APB1ENR_I2C1EN;
+        else if (p==I2C2) RCC->APB1ENR &= ~RCC_APB1ENR_I2C2EN;
+        else if (p==I2C3) RCC->APB1ENR &= ~RCC_APB1ENR_I2C3EN;
+    }
+}
+void I2C_PeripheralControl(I2C_RegDef_t *p, uint8_t En) { if (En) p->CR1 |= 1U; else p->CR1 &= ~1U; }
+void I2C_ManageAcking(I2C_RegDef_t *p, uint8_t En) { if (En) p->CR1 |= (1U<<10); else p->CR1 &= ~(1U<<10); }
+
+void I2C_Init(I2C_Handle_t *h)
+{
+    uint32_t pclk1 = I2C_GetPCLK1Hz();
+    I2C_PeriClockControl(h->pI2Cx, ENABLE);
+    I2C_PeripheralControl(h->pI2Cx, DISABLE);
+
+    /* CR2: PCLK1 in MHz */
+    h->pI2Cx->CR2 = (pclk1/1000000U) & 0x3FU;
+
+    /* OAR1: own address */
+    h->pI2Cx->OAR1 = (1U<<14) | ((uint32_t)h->I2C_Config.I2C_DeviceAddress << 1U);
+
+    /* CCR/TRISE */
+    uint16_t ccr=0;
+    if (h->I2C_Config.I2C_SCLSpeed <= I2C_SCL_SPEED_SM) {
+        ccr = (uint16_t)(pclk1/(2U*h->I2C_Config.I2C_SCLSpeed)); if (ccr<4) ccr=4;
+        h->pI2Cx->CCR = ccr;
+        h->pI2Cx->TRISE = (pclk1/1000000U) + 1U; /* 1000ns */
+    } else {
+        h->pI2Cx->CCR = (1U<<15) | ((h->I2C_Config.I2C_FMDutyCycle==I2C_FM_DUTY_16_9)?(1U<<14):0U);
+        if (h->I2C_Config.I2C_FMDutyCycle==I2C_FM_DUTY_16_9) ccr=(uint16_t)(pclk1/(25U*h->I2C_Config.I2C_SCLSpeed));
+        else ccr=(uint16_t)(pclk1/(3U*h->I2C_Config.I2C_SCLSpeed));
+        if (!ccr) ccr=1U;
+        h->pI2Cx->CCR |= (ccr & 0x0FFFU);
+        h->pI2Cx->TRISE = ((pclk1/1000000U)*300U)/1000U + 1U; /* 300ns */
+    }
+
+    if (h->I2C_Config.I2C_ACKControl==I2C_ACK_ENABLE) I2C_ManageAcking(h->pI2Cx, ENABLE);
+    else I2C_ManageAcking(h->pI2Cx, DISABLE);
+
+    I2C_PeripheralControl(h->pI2Cx, ENABLE);
+    h->TxRxState = I2C_READY;
+}
+
+void I2C_DeInit(I2C_RegDef_t *p) { (void)p; /* minimal */ }
+
+void I2C_IRQInterruptConfig(uint8_t IRQNumber, uint8_t En)
+{
+    if (En) {
+        if (IRQNumber<32) NVIC->ISER[0] = (1U<<IRQNumber);
+        else NVIC->ISER[1] = (1U<<(IRQNumber%32U));
+    } else {
+        if (IRQNumber<32) NVIC->ICER[0] = (1U<<IRQNumber);
+        else NVIC->ICER[1] = (1U<<(IRQNumber%32U));
+    }
+}
+
+void I2C_IRQPriorityConfig(uint8_t IRQNumber, uint32_t prio)
+{
+    uint8_t iprx = IRQNumber/4U, section = IRQNumber%4U, shift = (8U*section)+(8U-4U);
+    NVIC->IPR[iprx] &= ~(0xFU<<shift);
+    NVIC->IPR[iprx] |=  ((prio & 0x0FU) << shift);
+}
+
+uint8_t I2C_MasterSendDataIT(I2C_Handle_t *h, uint8_t *tx, uint32_t len, uint8_t addr, uint8_t sr)
+{
+    if (h->TxRxState != I2C_READY || len==0) return h->TxRxState;
+    h->pTxBuffer=tx; h->TxLen=len; h->TxRxState=I2C_BUSY_IN_TX; h->DevAddr=addr; h->Sr=sr;
+    I2C_GenerateStart(h->pI2Cx);
+    h->pI2Cx->CR2 |= (1U<<9) | (1U<<10) | (1U<<8);
+    return I2C_READY;
+}
+
+uint8_t I2C_MasterReceiveDataIT(I2C_Handle_t *h, uint8_t *rx, uint32_t len, uint8_t addr, uint8_t sr)
+{
+    if (h->TxRxState != I2C_READY || len==0) return h->TxRxState;
+    h->pRxBuffer=rx; h->RxLen=len; h->RxSize=len; h->TxRxState=I2C_BUSY_IN_RX; h->DevAddr=addr; h->Sr=sr;
+    I2C_GenerateStart(h->pI2Cx);
+    h->pI2Cx->CR2 |= (1U<<9) | (1U<<10) | (1U<<8);
+    return I2C_READY;
+}
+
+void I2C_EV_IRQHandling(I2C_Handle_t *h)
+{
+    uint32_t sr1 = h->pI2Cx->SR1;
+
+    /* SB: start bit sent */
+    if (sr1 & I2C_FLAG_SB) {
+        if (h->TxRxState==I2C_BUSY_IN_TX) I2C_ExecuteAddrPhaseWrite(h->pI2Cx, h->DevAddr);
+        else if (h->TxRxState==I2C_BUSY_IN_RX) I2C_ExecuteAddrPhaseRead(h->pI2Cx, h->DevAddr);
+    }
+
+    /* ADDR: address matched/completed */
+    if (sr1 & I2C_FLAG_ADDR) {
+        if (h->TxRxState==I2C_BUSY_IN_RX) {
+            if (h->RxSize==1U) I2C_ManageAcking(h->pI2Cx, DISABLE);
+            else if (h->RxSize==2U) I2C_ManageAcking(h->pI2Cx, DISABLE);
+        }
+        I2C_ClearADDRFlag(h);
+    }
+
+    /* TXE: write next byte */
+    if ((sr1 & I2C_FLAG_TXE) && (h->TxRxState==I2C_BUSY_IN_TX)) {
+        if (h->TxLen>0U) { h->pI2Cx->DR = *(h->pTxBuffer++); h->TxLen--; }
+    }
+
+    /* BTF: all bytes shifted and DR empty */
+    if (sr1 & I2C_FLAG_BTF) {
+        if (h->TxRxState==I2C_BUSY_IN_TX && h->TxLen==0U && (h->pI2Cx->SR1 & I2C_FLAG_TXE)) {
+            if (h->Sr==RESET) I2C_GenerateStop(h->pI2Cx);
+            I2C_CloseSendData(h);
+            I2C_ApplicationEventCallback(h, I2C_EV_TX_CMPLT);
+        }
+    }
+
+    /* RXNE: read incoming */
+    if ((sr1 & I2C_FLAG_RXNE) && (h->TxRxState==I2C_BUSY_IN_RX)) {
+        if (h->RxSize==1U) {
+            if (h->Sr==RESET) I2C_GenerateStop(h->pI2Cx);
+            *(h->pRxBuffer) = h->pI2Cx->DR; h->RxLen--; h->RxSize--;
+            I2C_CloseReceiveData(h);
+            I2C_ApplicationEventCallback(h, I2C_EV_RX_CMPLT);
+        } else {
+            if (h->RxLen==2U) { I2C_ManageAcking(h->pI2Cx, DISABLE); if (h->Sr==RESET) I2C_GenerateStop(h->pI2Cx); }
+            *(h->pRxBuffer++) = h->pI2Cx->DR; h->RxLen--;
+            if (h->RxLen==0U) { I2C_CloseReceiveData(h); I2C_ApplicationEventCallback(h, I2C_EV_RX_CMPLT); }
+        }
+    }
+
+    /* STOPF: slave mode only (included for completeness) */
+    if (sr1 & I2C_FLAG_STOPF) { (void)h->pI2Cx->SR1; h->pI2Cx->CR1 |= 0; I2C_ApplicationEventCallback(h, I2C_EV_STOP); }
+}
+
+void I2C_ER_IRQHandling(I2C_Handle_t *h)
+{
+    uint32_t sr1 = h->pI2Cx->SR1;
+    if (sr1 & I2C_ERR_BERR)    { h->pI2Cx->SR1 &= ~I2C_ERR_BERR;    I2C_ApplicationEventCallback(h, I2C_ERROR_BERR); }
+    if (sr1 & I2C_ERR_ARLO)    { h->pI2Cx->SR1 &= ~I2C_ERR_ARLO;    I2C_ApplicationEventCallback(h, I2C_ERROR_ARLO); }
+    if (sr1 & I2C_ERR_AF)      { h->pI2Cx->SR1 &= ~I2C_ERR_AF;      I2C_ApplicationEventCallback(h, I2C_ERROR_AF); }
+    if (sr1 & I2C_ERR_OVR)     { h->pI2Cx->SR1 &= ~I2C_ERR_OVR;     I2C_ApplicationEventCallback(h, I2C_ERROR_OVR); }
+    if (sr1 & I2C_ERR_TIMEOUT) { h->pI2Cx->SR1 &= ~I2C_ERR_TIMEOUT; I2C_ApplicationEventCallback(h, I2C_ERROR_TIMEOUT); }
+}
+
+uint8_t I2C_GetFlagStatus(I2C_RegDef_t *p, uint32_t flag) { return (p->SR1 & flag) ? SET : RESET; }
+
+void __attribute__((weak)) I2C_ApplicationEventCallback(I2C_Handle_t *p, uint8_t e) { (void)p; (void)e; }

--- a/I2C_IRQ/Makefile
+++ b/I2C_IRQ/Makefile
@@ -1,0 +1,34 @@
+.RECIPEPREFIX := >
+CC        = arm-none-eabi-gcc
+OBJCOPY   = arm-none-eabi-objcopy
+SIZE      = arm-none-eabi-size
+
+TARGET    = I2C_IRQ
+BUILD     = build
+
+MCU       = -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 -mfloat-abi=softfp
+CDEFS     = -DSTM32F407xx
+CINCS     = -IDrivers/inc
+CFLAGS    = $(MCU) -O0 -g3 -Wall -ffunction-sections -fdata-sections $(CDEFS) $(CINCS)
+LDFLAGS   = $(MCU) -Wl,--gc-sections -TSTM32F407VGTx_FLASH.ld
+
+SRCS = main.c stm32f407xx_gpio_driver.c stm32f407xx_i2c_driver.c
+VPATH = . Drivers/src
+
+OBJS = $(patsubst %.c,$(BUILD)/%.o,$(SRCS))
+
+all: $(BUILD)/$(TARGET).elf $(BUILD)/$(TARGET).hex
+
+$(BUILD)/%.o: %.c
+> @mkdir -p $(dir $@)
+> $(CC) $(CFLAGS) -c $< -o $@
+
+$(BUILD)/$(TARGET).elf: $(OBJS)
+> $(CC) $(OBJS) $(LDFLAGS) -o $@
+> $(SIZE) $@
+
+$(BUILD)/$(TARGET).hex: $(BUILD)/$(TARGET).elf
+> $(OBJCOPY) -O ihex $< $@
+
+clean:
+> rm -rf $(BUILD)

--- a/I2C_IRQ/STM32F407VGTx_FLASH.ld
+++ b/I2C_IRQ/STM32F407VGTx_FLASH.ld
@@ -1,0 +1,36 @@
+/* File: STM32F407VGTx_FLASH.ld */
+ENTRY(Reset_Handler)
+
+MEMORY
+{
+  FLASH (rx)  : ORIGIN = 0x08000000, LENGTH = 1024K
+  SRAM  (rwx) : ORIGIN = 0x20000000, LENGTH = 192K
+}
+
+SECTIONS
+{
+  .isr_vector : { KEEP(*(.isr_vector)) } > FLASH
+
+  .text :
+  {
+    *(.text*) *(.rodata*) *(.glue_7) *(.glue_7t)
+    KEEP(*(.init)) KEEP(*(.fini))
+  } > FLASH
+
+  .ARM.extab   : { *(.ARM.extab* .gnu.linkonce.armextab.*) } > FLASH
+  .ARM.exidx   : { *(.ARM.exidx*) } > FLASH
+
+  .eh_frame : { *(.eh_frame*) } > FLASH
+
+  .data : AT (ADDR(.text) + SIZEOF(.text))
+  {
+    _sdata = .; *(.data*)  _edata = .;
+  } > SRAM
+
+  .bss :
+  {
+    _sbss = .; *(.bss*) *(COMMON) _ebss = .;
+  } > SRAM
+
+  _estack = ORIGIN(SRAM) + LENGTH(SRAM);
+}

--- a/I2C_IRQ/main.c
+++ b/I2C_IRQ/main.c
@@ -1,0 +1,70 @@
+#include "stm32f407xx.h"
+#include "stm32f407xx_gpio_driver.h"
+#include "stm32f407xx_i2c_driver.h"
+#include <stdio.h>
+
+/* PB6=SCL, PB9=SDA */
+#define I2C_SCL_PIN 6
+#define I2C_SDA_PIN 9
+#define SLAVE_ADDR  0x68   /* change to your target */
+
+static I2C_Handle_t I2C1Handle;
+static uint8_t rxBuf[6];
+
+static void I2C1_GPIO_Init(void)
+{
+    GPIO_Handle_t g; g.pGPIOx = GPIOB;
+    g.GPIO_PinConfig.GPIO_PinMode = GPIO_MODE_ALTFN;
+    g.GPIO_PinConfig.GPIO_PinOPType = GPIO_OP_TYPE_OD;
+    g.GPIO_PinConfig.GPIO_PinPuPdControl = GPIO_PIN_PU;
+    g.GPIO_PinConfig.GPIO_PinSpeed = GPIO_SPEED_HIGH;
+    g.GPIO_PinConfig.GPIO_PinAltFunMode = 4; /* AF4 */
+
+    g.GPIO_PinConfig.GPIO_PinNumber = I2C_SCL_PIN; GPIO_Init(&g);
+    g.GPIO_PinConfig.GPIO_PinNumber = I2C_SDA_PIN; GPIO_Init(&g);
+}
+
+static void I2C1_Init_100kHz(void)
+{
+    I2C1Handle.pI2Cx = I2C1;
+    I2C1Handle.I2C_Config.I2C_SCLSpeed = I2C_SCL_SPEED_SM;
+    I2C1Handle.I2C_Config.I2C_DeviceAddress = 0x61; /* own addr */
+    I2C1Handle.I2C_Config.I2C_ACKControl = I2C_ACK_ENABLE;
+    I2C1Handle.I2C_Config.I2C_FMDutyCycle = I2C_FM_DUTY_2;
+    I2C_Init(&I2C1Handle);
+}
+
+int main(void)
+{
+    I2C1_GPIO_Init();
+    I2C1_Init_100kHz();
+
+    /* NVIC */
+    I2C_IRQPriorityConfig(IRQ_NO_I2C1_ER, 0);
+    I2C_IRQPriorityConfig(IRQ_NO_I2C1_EV, 1);
+    I2C_IRQInterruptConfig(IRQ_NO_I2C1_ER, ENABLE);
+    I2C_IRQInterruptConfig(IRQ_NO_I2C1_EV, ENABLE);
+
+    /* Start an IRQ-based read of 6 bytes */
+    I2C_MasterReceiveDataIT(&I2C1Handle, rxBuf, sizeof(rxBuf), SLAVE_ADDR, RESET);
+
+    while (1) { /* idle */ }
+}
+
+/* Vector forwarding */
+void I2C1_EV_IRQHandler(void) { I2C_EV_IRQHandling(&I2C1Handle); }
+void I2C1_ER_IRQHandler(void) { I2C_ER_IRQHandling(&I2C1Handle); }
+
+/* App callback */
+void I2C_ApplicationEventCallback(I2C_Handle_t *h, uint8_t evt)
+{
+    if (evt == I2C_EV_RX_CMPLT) {
+        printf("RX: ");
+        for (uint32_t i=0;i<h->RxSize;i++) printf("%02X ", rxBuf[i]);
+        printf("\n");
+    } else if (evt == I2C_ERROR_AF)      { printf("I2C: NACK\n"); }
+      else if (evt == I2C_ERROR_BERR)    { printf("I2C: Bus error\n"); }
+      else if (evt == I2C_ERROR_ARLO)    { printf("I2C: Arbitration lost\n"); }
+      else if (evt == I2C_ERROR_OVR)     { printf("I2C: Overrun\n"); }
+      else if (evt == I2C_ERROR_TIMEOUT) { printf("I2C: Timeout\n"); }
+}


### PR DESCRIPTION
## Summary
- Add minimal STM32F407 GPIO and I2C drivers with interrupt-driven master receive support
- Provide example `main.c` that configures PB6/PB9 for I2C1 and reads 6 bytes via IRQs
- Include Makefile and linker script for building the example

## Testing
- `make` *(fails: arm-none-eabi-gcc: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ad18f5f3108333ac190c781002c181